### PR TITLE
Version lock to any 26.1 variant

### DIFF
--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -96,6 +96,6 @@
 "deps.fzzy-config"="0.7.6+26.1"
 
 ["26.1-fabric"]
-"deps.minecraft"="26.1"
+"deps.minecraft"="~26.1"
 "deps.fabric-api"="0.144.0+26.1"
 "deps.fzzy-config"="0.7.6+26.1"


### PR DESCRIPTION
Since 26.1 we are back an major.minor.patch with patch being supposedly compatible. Change the versionlock to match all 26.1 variants. 